### PR TITLE
Add C.EBREAK to the table generator, and add support for 32-bit instructions

### DIFF
--- a/riscv_c2g_gen.c
+++ b/riscv_c2g_gen.c
@@ -15,6 +15,7 @@
 #define CRV_IOP_OP     0x33
 #define CRV_IOP_OP32   0x3B
 #define CRV_IOP_IMM32  0x1B
+#define CRV_IOP_SYSTEM 0x73
 //############################################################################//
 //CRV_IOP_IMM
 #define CRV_F3_ADDI    0
@@ -39,6 +40,8 @@
 #define CRV_F3_AND     7
 //CRV_IOP_OP32
 #define CRV_F3_ADDSUBW 0
+//CRV_IOP_SYSTEM
+#define CRV_F3_EBREAK  0
 //############################################################################//
 #define OP_C0 0
 #define OP_C1 1
@@ -314,7 +317,7 @@ uint64_t crv_decompress_real(const uint16_t cmd)
     }
     case 1:switch (b) {
      case 0:switch (a) {
-      case 0: return 0;                                                                         //c.ebreak
+      case 0: return crv_compose_i(CRV_IOP_SYSTEM,0,0,CRV_F3_EBREAK,1);                         //c.ebreak
       default:return crv_compose_i(CRV_IOP_JALR,a,1,0,0);                                       //c.jalr
      }
      default: return crv_compose_r(CRV_IOP_OP,a,b,a,CRV_F3_ADDSUB,0);                           //c.add

--- a/riscv_c2g_gen.c
+++ b/riscv_c2g_gen.c
@@ -274,7 +274,11 @@ uint64_t crv_decompress_real(const uint16_t cmd)
     case 0: return crv_compose_i(CRV_IOP_IMM,0,0,CRV_F3_ADDI,0);                               //c.nop
     default:return crv_compose_i(CRV_IOP_IMM,a,a,CRV_F3_ADDI,imm_c1m0(cmd));                   //c.addi
    }
+#ifdef RV32C
+   case OPC_M1:return crv_compose_j(CRV_IOP_JAL,1,imm_c1m5(cmd));                              // c.jal
+#else
    case OPC_M1:return crv_compose_i(CRV_IOP_IMM32,a,a,CRV_F3_ADDIW,imm_c1m0(cmd));             //c.addiw
+#endif
    case OPC_M2:return crv_compose_i(CRV_IOP_IMM,0,a,CRV_F3_ADDI,imm_c1m0(cmd));                //c.li
    case OPC_M3:switch (a) {
     case 2:  return crv_compose_i(CRV_IOP_IMM,2,2,CRV_F3_ADDI,imm_c1m3(cmd));                  //c.addi16sp


### PR DESCRIPTION
In the latest commit the C.EBREAK instruction was added to the header file riscv_c2g_lut_c2.h, but the table generator was not updated to actually include this change. The first commit below adds this instruction to the table generator.

The second commit adds support for the 32-bit RV32C instruction set. As far as I can tell there is only a single instruction that differs between RV64C and RV32C (c.addiw is replaced by c.jal). The second commit makes this change and hides it behind the compilation flag RV32C.

